### PR TITLE
Fix markdown headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 ![bíogo](https://raw.githubusercontent.com/biogo/biogo/master/biogo.png)
 
-#Illumina
+# Illumina
 
 [![Build Status](https://travis-ci.org/biogo/illumina.svg?branch=master)](https://travis-ci.org/biogo/illumina)
 
-##Installation
+## Installation
 
         $ go get github.com/biogo/illumina/...
 
-##Overview
+## Overview
 
 Illumina is a set of utilities for handling Illumina™ sequencing data.
 
-## Citing ##
+## Citing 
 
 If you use bíogo, please cite Kortschak and Adelson "bíogo: a simple high-performance bioinformatics toolkit for the Go language", doi:[10.1101/005033](http://biorxiv.org/content/early/2014/05/12/005033).
 
-##Library Structure and Coding Style
+## Library Structure and Coding Style
 
 The coding style should be aligned with normal Go idioms as represented in the
 Go core libraries.
 
-##Copyright and License
+## Copyright and License
 
 Copyright ©2011-2013 The bíogo Authors except where otherwise noted. All rights
 reserved. Use of this source code is governed by a BSD-style license that can be


### PR DESCRIPTION
Add spaces after `#` so text appears as markdown headers